### PR TITLE
Feature: Return the needed HTML includes for a guest frame

### DIFF
--- a/Classes/Fusion/Backend/ParseIncludesImplementation.php
+++ b/Classes/Fusion/Backend/ParseIncludesImplementation.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Networkteam\Neos\ContentApi\Fusion\Backend;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Exception as FusionException;
+use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Neos\Service\LinkingService;
+use Neos\Media\Domain\Model\Asset;
+use Neos\Media\Domain\Model\Image;
+use Neos\Media\Domain\Model\ImageVariant;
+use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Media\Domain\Service\AssetService;
+use Neos\Flow\ResourceManagement\ResourceManager;
+use Networkteam\Neos\ContentApi\Exception;
+
+class ParseIncludesImplementation extends AbstractFusionObject
+{
+
+    protected function getHtml()
+    {
+        return $this->fusionValue('html');
+    }
+
+    /**
+     * Parse given HTML and return a structured representation
+     *
+     * @return array
+     * @throws Exception
+     */
+    public function evaluate()
+    {
+       return self::parseHTML($this->getHtml());
+    }
+
+    /**
+     * @throws Exception
+     * @internal It's public to make it easily testable
+     */
+    public static function parseHTML($html) {
+        $dom = new \DOMDocument();
+        $success = @$dom->loadHTML($html); // use @ to suppress warnings
+        if ($success !== true) {
+            throw new Exception('Failed to parse HTML', 1685618008);
+        }
+        $scripts = $dom->getElementsByTagName('script');
+        $links = $dom->getElementsByTagName('link');
+
+        $result = [];
+        $counter = 1;
+
+        foreach ($scripts as $script) {
+            $key = 'script-' . $counter++;
+            if ($script->nodeValue) {
+                $result[] = ['key' => $key, 'type' => 'script', 'content' => $script->nodeValue];
+            } else {
+                $result[] = ['key' => $key, 'type' => 'script', 'src' => $script->getAttribute('src')];
+            }
+        }
+
+        foreach ($links as $link) {
+            $key = 'link-' . $counter++;
+            $result[] = ['key' => $key, 'type' => 'link', 'href' => $link->getAttribute('href'), 'rel' => $link->getAttribute('rel')];
+        }
+
+        return $result;
+    }
+
+}

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -69,8 +69,10 @@ prototype(Networkteam.Neos.ContentApi:DefaultDocument) < prototype(Neos.Fusion:D
     }
 
     # Return the HTML includes (CSS, JS) needed in the guest frame
-    guestFrameApplication = Neos.Fusion:Renderer {
-      renderPath = "/contentApiPage/head/guestFrameApplication"
+    guestFrameApplication = Networkteam.Neos.ContentApi:Backend.ParseIncludes {
+      html = Neos.Fusion:Renderer {
+        renderPath = "/contentApiPage/head/guestFrameApplication"
+      }
     }
 
     @if {
@@ -174,4 +176,8 @@ prototype(Networkteam.Neos.ContentApi:Backend.EditPreviewMode) < prototype(Neos.
   isPreview = ${this.mode.preview}
   isEdit = ${this.mode.edit}
   options = ${this.mode.options}
+}
+
+prototype(Networkteam.Neos.ContentApi:Backend.ParseIncludes) {
+  @class = 'Networkteam\\Neos\\ContentApi\\Fusion\\Backend\\ParseIncludesImplementation'
 }

--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -68,11 +68,19 @@ prototype(Networkteam.Neos.ContentApi:DefaultDocument) < prototype(Neos.Fusion:D
       mode = ${documentNode.context.currentRenderingMode}
     }
 
+    # Return the HTML includes (CSS, JS) needed in the guest frame
+    guestFrameApplication = Neos.Fusion:Renderer {
+      renderPath = "/contentApiPage/head/guestFrameApplication"
+    }
+
     @if {
       inBackend = ${documentNode.context.inBackend}
     }
   }
 }
+
+# We need to declare a path to render only a specfic part of the page
+contentApiPage = Neos.Neos:Page
 
 prototype(Networkteam.Neos.ContentApi:BaseNode) < prototype(Neos.Fusion:DataStructure) {
   identifier = ${node.identifier}

--- a/Tests/Unit/Fusion/Backend/ParseIncludesImplementationTest.php
+++ b/Tests/Unit/Fusion/Backend/ParseIncludesImplementationTest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Networkteam\Neos\ContentApi\Tests\Unit\Fusion\Backend;
+
+use Networkteam\Flow\CommandMigrations\ValueObject\CommandDefinitionId;
+use Neos\Flow\Tests\UnitTestCase;
+use Networkteam\Neos\ContentApi\Fusion\Backend\ParseIncludesImplementation;
+
+class ParseIncludesImplementationTest extends UnitTestCase
+{
+
+    public function parseHTMLExamples()
+    {
+
+        $html = <<<HTML
+        <script>window.neos = window.parent.neos;</script>
+        <script src="http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/JavaScript/Vendor.js"></script>
+        <script src="http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui/Plugins/ckeditor/ckeditor.js"></script>
+        <script src="http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/JavaScript/Guest.js"></script>
+        <link rel="stylesheet" href="http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/Styles/Host.css">
+        <link rel="stylesheet" href="http://localhost:3000/_Resources/Static/Packages/Shel.Neos.Hyphens/HyphensEditor/Plugin.css" />
+        HTML;
+
+        return [
+            [
+                $html,
+                [
+                    ['key' => 'script-1', 'type' => 'script', 'content' => 'window.neos = window.parent.neos;'],
+                    ['key' => 'script-2', 'type' => 'script', 'src' => 'http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/JavaScript/Vendor.js'],
+                    ['key' => 'script-3', 'type' => 'script', 'src' => 'http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui/Plugins/ckeditor/ckeditor.js'],
+                    ['key' => 'script-4', 'type' => 'script', 'src' => 'http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/JavaScript/Guest.js'],
+                    ['key' => 'link-5', 'type' => 'link', 'href' => 'http://localhost:3000/_Resources/Static/Packages/Neos.Neos.Ui.Compiled/Styles/Host.css', 'rel' => 'stylesheet'],
+                    ['key' => 'link-6', 'type' => 'link', 'href' => 'http://localhost:3000/_Resources/Static/Packages/Shel.Neos.Hyphens/HyphensEditor/Plugin.css', 'rel' => 'stylesheet']
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param string $html
+     * @param array $expectedIncludes
+     * @test
+     * @dataProvider parseHTMLExamples
+     */
+    public function parseHTMLTests(string $html, array $expectedIncludes)
+    {
+        $includes = ParseIncludesImplementation::parseHTML($html);
+        $this->assertEquals($expectedIncludes, $includes);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "name": "networkteam/neos-contentapi",
     "require": {
         "neos/neos": "^7.3 || ^8.0",
-        "networkteam/neos-util": "^8.0"
+        "networkteam/neos-util": "^8.0",
+        "ext-dom": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is part of a fix for https://github.com/networkteam/zebra/issues/5 to remove the actual includes of the Neos UI from Zebra and use the existing Fusion code and extensibility mechanisms in Neos.