### PR TITLE
task: Allow redirects to external URLs

### DIFF
--- a/Classes/Controller/DocumentsController.php
+++ b/Classes/Controller/DocumentsController.php
@@ -383,7 +383,9 @@ class DocumentsController extends ActionController
         }
 
         return [
-            'targetPath' => '/' . ltrim($redirect->getTargetUriPath(), '/'),
+			'targetPath' => parse_url($redirect->getTargetUriPath(), PHP_URL_SCHEME) === null ?
+                '/' . ltrim($redirect->getTargetUriPath(), '/')
+                : $redirect->getTargetUriPath(),
             'statusCode' => $redirect->getStatusCode(),
         ];
     }


### PR DESCRIPTION
The redirect module allows external URLs as redirect target. External URLs must not be prepended with a slash.
Next's `redirect()` handles external URLs flawlessly.